### PR TITLE
ロッカージェスチャーで新しく開いたタブに移動した後にコンテキストメニューが開く問題を修正

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -345,7 +345,15 @@ class MouseGestureAndWheelActionClient {
             }
 
             if (event.button === 2) {
-                this.#isRightButtonPressed = false;
+                if (this.#isRightButtonPressed) {
+                    this.#isRightButtonPressed = false;
+                }
+                else {
+                    // It should have been moved from another tab with the right button held down, so ignore the mouseup event
+                    // and prevent the context menu from appearing.
+                    global.shouldPreventContextMenu = true;
+                    return; 
+                }
             }
 
             // Mouse Gesture


### PR DESCRIPTION
ロッカージェスチャーで右ボタンを押したまま新しく開いたタブに移動した後